### PR TITLE
content-type をセット

### DIFF
--- a/lib/bunyan-slack.js
+++ b/lib/bunyan-slack.js
@@ -86,6 +86,9 @@ BunyanSlack.prototype.write = function write(record) {
   request.post({
     url: url,
     body: JSON.stringify(message)
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
   .on('error', function(err) {
     return self.error(err);


### PR DESCRIPTION
## 概要

チャットのバージョンアップにより webhook にPOSTする際には content-type をセットする必要があったため、
ヘッダーにセットするようにしました。